### PR TITLE
Make Object.keys work for fallbacks

### DIFF
--- a/.github/workflows/webpack.yml
+++ b/.github/workflows/webpack.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [12.x, 14.x, 16.x, 18.x]
     
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/webpack.yml
+++ b/.github/workflows/webpack.yml
@@ -1,0 +1,30 @@
+name: NodeJS with Webpack
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 16.x]
+    
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Build
+      run: |
+        npm install
+        npm run validate
+        npm run clean
+        tsc

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm run validate

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "files": [
     "/lib/src",
+    "src",
     "LICENSE",
     "README.md"
   ],

--- a/package.json
+++ b/package.json
@@ -11,15 +11,17 @@
     "validate": "npm run lint && npm test",
     "clean": "rimraf lib",
     "prepublishOnly": "npm run validate && npm run clean && tsc",
-    "prepare": "husky install && npm run clean && tsc"
+    "prepare": "husky install"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/maxk096/deep-fallback.git"
   },
+  "engines": {
+    "node": ">=12"
+  },
   "files": [
     "/lib/src",
-    "src",
     "LICENSE",
     "README.md"
   ],

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "validate": "npm run lint && npm test",
     "clean": "rimraf lib",
     "prepublishOnly": "npm run validate && npm run clean && tsc",
-    "prepare": "husky install"
+    "prepare": "npm install && husky install && npm run clean && tsc"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "validate": "npm run lint && npm test",
     "clean": "rimraf lib",
     "prepublishOnly": "npm run validate && npm run clean && tsc",
-    "prepare": "npm install && husky install && npm run clean && tsc"
+    "prepare": "husky install && npm run clean && tsc"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -10,12 +10,8 @@
     "test:watch": "jest --watch",
     "validate": "npm run lint && npm test",
     "clean": "rimraf lib",
-    "prepublishOnly": "npm run validate && npm run clean && tsc"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "npm run validate"
-    }
+    "prepublishOnly": "npm run validate && npm run clean && tsc",
+    "prepare": "husky install"
   },
   "repository": {
     "type": "git",
@@ -47,18 +43,18 @@
     "@types/is-object": "1.0.1",
     "@types/jest": "26.0.15",
     "@types/lodash.get": "4.4.6",
-    "@typescript-eslint/eslint-plugin": "4.7.0",
-    "@typescript-eslint/parser": "4.7.0",
+    "@typescript-eslint/eslint-plugin": "^5.36.2",
+    "@typescript-eslint/parser": "^5.36.2",
     "conditional-type-checks": "^1.0.5",
     "eslint": "7.13.0",
     "eslint-config-prettier": "6.15.0",
     "eslint-plugin-prettier": "3.1.4",
-    "husky": "4.3.0",
+    "husky": "^8.0.0",
     "jest": "26.6.3",
-    "prettier": "2.1.2",
+    "prettier": "^2.7.1",
     "rimraf": "3.0.2",
     "ts-jest": "26.4.4",
-    "typescript": "4.0.5"
+    "typescript": "^4.8.2"
   },
   "dependencies": {
     "is-object": "1.0.1",

--- a/src/fallback-me.ts
+++ b/src/fallback-me.ts
@@ -61,6 +61,47 @@ const fallbackMe = (fallback: FallbackBase): any => {
       });
       return fallbackMe(nextFallback);
     },
+    ownKeys(target) {
+      const allFallbackKeys = fallbacks.reduce<Array<string | symbol>>(
+        (result, currentFallback) => {
+          if (!currentFallback || typeof currentFallback !== 'object') {
+            return result;
+          }
+
+          const currentFallbackPropValue = path.length
+            ? get(currentFallback, path)
+            : currentFallback;
+
+          if (currentFallbackPropValue) {
+            const currentKeys = Object.keys(currentFallbackPropValue);
+
+            for (const key of currentKeys) {
+              if (!result.includes(key)) {
+                result.push(key);
+              }
+            }
+          }
+
+          return result;
+        },
+        Reflect.ownKeys(target)
+      );
+
+      return allFallbackKeys;
+    },
+    getOwnPropertyDescriptor(target, prop) {
+      const propertyDescriptor = Object.getOwnPropertyDescriptor(target, prop);
+
+      if (propertyDescriptor) {
+        return propertyDescriptor;
+      }
+
+      return {
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      };
+    },
   });
 
   return proxy;


### PR DESCRIPTION
Hi!

Thank you for creating this awesome library. I'm really impressed by how solid it is!

This PR makes `Object.keys`, `{ ...res }` etc. work for the fallback - in case this is something you'd like included in the main branch :)

Also updates husky to fix vulns, and updates typescript, prettier, @typescript-eslint-stuff to make the project run.